### PR TITLE
refactor: Replace <img/> with Next.js <Image/> component

### DIFF
--- a/src/common/components/Header/Header.tsx
+++ b/src/common/components/Header/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, Fragment } from 'react'
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions, Transition } from '@headlessui/react'
+import Image, { StaticImageData } from 'next/image'
 import Link from 'next/link'
 import { twMerge } from 'tailwind-merge'
 import { Icon, Button } from '@/common/components'
@@ -13,7 +14,12 @@ type HeaderPropsType = {
   notifCounter?: number
 }
 
-const langs = [
+type LangType = {
+  title: string
+  path: StaticImageData
+}
+
+const langs: LangType[] = [
   { title: 'English', path: flagUK },
   { title: 'Russian', path: flagRussia },
 ]
@@ -72,7 +78,8 @@ export const Header = ({ isAdmin = false, isAuth, notifCounter = 100 }: HeaderPr
                 <div className='relative w-[164px]'>
                   <ListboxButton className='bg-dark-800 flex h-[36px] w-full cursor-pointer items-center justify-between border border-[var(--color-dark-300)] px-2 text-white'>
                     <div className='flex items-center gap-3'>
-                      <img src={currLang?.path.src} alt={lang} className='h-5 w-5 object-cover' />
+                      {currLang && <Image src={currLang?.path.src} alt={lang} className='h-5 w-5 object-cover' />}
+
                       <span className='block truncate'>{lang}</span>
                     </div>
                     {open ? (
@@ -101,7 +108,7 @@ export const Header = ({ isAdmin = false, isAuth, notifCounter = 100 }: HeaderPr
                         >
                           {({ selected }) => (
                             <>
-                              <img src={path.src} alt={title} className='h-5 w-5 object-cover' />
+                              <Image src={path.src} alt={title} className='h-5 w-5 object-cover' />
                               <span className={`block truncate ${selected ? 'font-medium' : 'font-normal'}`}>
                                 {title}
                               </span>

--- a/src/common/components/SelectBox/SelectBox.tsx
+++ b/src/common/components/SelectBox/SelectBox.tsx
@@ -2,8 +2,9 @@
 
 import React, { FC, ReactNode } from 'react'
 import { Field, Label, Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
-import { Icon } from '../Icon/Icon'
+import Image from 'next/image'
 import { twMerge } from 'tailwind-merge'
+import { Icon } from '@/common/components'
 
 export type OptionType<T = string> = {
   value: T
@@ -36,7 +37,7 @@ export const SelectBox: FC<SelectBoxProps> = ({
     if (!icon) return null
 
     if (typeof icon === 'string') {
-      return <img src={icon} alt={alt || ''} className='h-5 w-5 object-cover' />
+      return <Image src={icon} alt={alt || ''} className='h-5 w-5 object-cover' />
     }
 
     return icon


### PR DESCRIPTION
### Resolves #33
This PR replaces all instances of the standard `<img>` tag with the Next.js `<Image>` component.