### PR TITLE
feat(ui): [I20-62] Add polymorphic Typography component

### DIFF
--- a/src/common/components/Icon/Icon.stories.tsx
+++ b/src/common/components/Icon/Icon.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Meta, StoryObj } from '@storybook/nextjs'
 import { Icon } from './Icon'
+import { Typography } from '@/common/components'
 import { iconIds } from '@/common/types'
 
 const meta: Meta<typeof Icon> = {
@@ -50,7 +51,7 @@ export const IconGallery: Story = {
           className='flex size-35 flex-col items-center justify-center rounded-2xl border-2 border-solid border-black px-2 py-1.5'
         >
           <Icon {...args} iconId={id} />
-          <p className='mt-2 text-center text-[16px] font-bold text-gray-600'>{id}</p>
+          <Typography className='mt-2 text-center text-[16px] font-bold text-gray-600'>{id}</Typography>
         </div>
       ))}
     </div>

--- a/src/common/components/Typography/Typography.stories.tsx
+++ b/src/common/components/Typography/Typography.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Typography } from './Typography'
+
+const meta: Meta<typeof Typography> = {
+  title: 'UI Kit/Typography',
+  component: Typography,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['p', 'h1', 'h2', 'h3', 'large'],
+      description: 'Визуальный стиль текста',
+    },
+    as: {
+      control: 'text',
+      description: 'HTML-тег или другой компонент для рендеринга',
+    },
+    children: {
+      control: 'text',
+      description: 'Содержимое компонента',
+    },
+    className: {
+      control: 'text',
+      description: 'Дополнительные CSS-классы',
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    variant: 'p',
+    children: 'Это обычный текст параграфа (variant="p").',
+  },
+}
+
+export const Heading1: Story = {
+  args: {
+    variant: 'h1',
+    children: 'Это заголовок первого уровня (variant="h1").',
+  },
+}
+
+export const Heading2: Story = {
+  args: {
+    variant: 'h2',
+    children: 'Это заголовок второго уровня (variant="h2").',
+  },
+}
+
+export const LargeText: Story = {
+  args: {
+    variant: 'large',
+    children: 'Это большой текст (variant="large").',
+  },
+}
+
+export const LargeTextAsH3: Story = {
+  args: {
+    variant: 'large',
+    as: 'h3',
+    children: 'Визуально large, но семантически H3.',
+  },
+}
+
+export const WithCustomClassName: Story = {
+  args: {
+    variant: 'p',
+    children: 'Этот текст синий и курсивный.',
+    className: 'text-blue-500 italic',
+  },
+}

--- a/src/common/components/Typography/Typography.tsx
+++ b/src/common/components/Typography/Typography.tsx
@@ -1,0 +1,50 @@
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from 'react'
+import { cn } from '@/common/utils'
+
+type TypographyVariant = 'p' | 'large' | 'h1' | 'h2' | 'h3' | 'link'
+
+const variantClasses: Record<TypographyVariant, string> = {
+  p: 'text-sm font-normal leading-relaxed',
+  large: 'text-2xl font-semibold leading-snug',
+  h1: 'text-xl font-bold leading-relaxed',
+  h2: 'text-xl font-semibold leading-tight',
+  h3: 'text-base font-semibold leading-normal',
+  link: 'text-accent-300 underline hover:text-accent-500',
+}
+
+type TypographyProps<T extends ElementType> = {
+  as?: T
+  children: ReactNode
+  className?: string
+  variant?: TypographyVariant
+} & Omit<ComponentPropsWithoutRef<T>, 'as' | 'children' | 'className' | 'variant'>
+
+export const Typography = <T extends ElementType = 'p'>({
+  as,
+  children,
+  className,
+  variant = 'p',
+  ...restProps
+}: TypographyProps<T>) => {
+  const Text = as || getDefaultComponent(variant)
+
+  return (
+    <Text className={cn(variantClasses[variant], className)} {...restProps}>
+      {children}
+    </Text>
+  )
+}
+
+const getDefaultComponent = (variant: TypographyVariant): ElementType => {
+  switch (variant) {
+    case 'large':
+    case 'h1':
+      return 'h1'
+    case 'h2':
+      return 'h2'
+    case 'h3':
+      return 'h3'
+    default:
+      return 'p'
+  }
+}

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -1,3 +1,5 @@
+export { Typography } from './Typography/Typography'
+
 export { Button } from './Button/Button'
 export { Header } from './Header/Header'
 export { Icon } from './Icon/Icon'

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Checkbox } from '@headlessui/react'
-import { Icon, Input, Button } from '@/common/components'
+import { Icon, Input, Button, Typography } from '@/common/components'
 
 export const SignUpPage = () => {
   const [enabled, setEnabled] = useState(true)
@@ -8,9 +8,9 @@ export const SignUpPage = () => {
   return (
     <div className='m-auto flex max-w-[378px] items-center justify-center bg-black'>
       <div className='bg-dark-700 border-dark-300 w-full max-w-md rounded-lg border p-8'>
-        <h2 className='mb-4 flex flex-col items-center justify-center text-xl text-[20px] font-semibold text-white'>
+        <Typography variant='h2' className='mb-4 flex flex-col items-center justify-center text-white'>
           Sign Up
-        </h2>
+        </Typography>
 
         <div className='mb-6 flex justify-center gap-15'>
           <a href={'https://www.google.com/'}>
@@ -40,24 +40,28 @@ export const SignUpPage = () => {
             </svg>
           </Checkbox>
 
-          <p className='w-full text-[12px] font-[var(--font-family-primary)] text-white italic'>
+          <Typography
+            as='p'
+            variant='p'
+            className='w-full text-[12px] font-[var(--font-family-primary)] text-white italic'
+          >
             I agree to the{' '}
-            <a href={'#'} className={'text-info-300 underline'}>
+            <Typography as='a' href={'#'} variant='link'>
               Terms of Service
-            </a>{' '}
+            </Typography>{' '}
             and{' '}
-            <a href={'#'} className={'text-info-300 underline'}>
+            <Typography as='a' href={'#'} variant='link'>
               Privacy Policy
-            </a>
-          </p>
+            </Typography>
+          </Typography>
         </div>
 
         <Button className={'w-full'} variant={'primary'} size={'large'} children={'Sign up'} />
 
         <div className='m-auto mt-4 text-center'>
-          <a href={'#'}>
-            <p className='mb-1 text-white'>Do you have an account?</p>
-          </a>
+          <Typography as={'a'} href={'#'} variant='p' className='mb-1 text-white'>
+            Do you have an account?
+          </Typography>
           <Button className={'text-info-500 w-full'} size={'large'} children={'Sign in'} />
         </div>
       </div>


### PR DESCRIPTION
This PR introduces a reusable `Typography` component to standardize text styles.

### Changes:
- Added a polymorphic `Typography` component  with predefined variants (`h1`, `p`, `link`, etc.)
- Included Storybook stories for documentation.
- Refactored `SignUpPage` to use the new component.